### PR TITLE
Convert parser state dispatch lookup by token to array

### DIFF
--- a/src/EmptyArray.cs
+++ b/src/EmptyArray.cs
@@ -1,0 +1,31 @@
+#region Copyright (c) 2017 Atif Aziz, Adrian Guerra
+//
+// Portions Copyright (c) 2013 Ivan Nikulin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+#endregion
+
+namespace High5
+{
+    static class EmptyArray<T>
+    {
+        public static readonly T[] Value = new T[0];
+    }
+}


### PR DESCRIPTION
The lookup used a dictionary but this PR directly indexes into an array.

``` 
BenchmarkDotNet=v0.10.9, OS=Mac OS X 10.12
Processor=Intel Core i7-3720QM CPU 2.60GHz (Ivy Bridge), ProcessorCount=8
.NET Core SDK=2.0.0
  [Host]     : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
```

Benchmark numbers of parent (4eee0e753aee4d66da160cddf958072f1274780d):

 |    Method |       Mean |     Error |    StdDev |      Gen 0 |     Gen 1 |     Gen 2 |   Allocated |
 |---------- |-----------:|----------:|----------:|-----------:|----------:|----------:|------------:|
 |       Lhc |   6.312 ms | 0.0692 ms | 0.0647 ms |  3406.2500 |  125.0000 |   54.6875 | 12106.07 KB |
 | NodeJsOrg |   1.268 ms | 0.0112 ms | 0.0104 ms |   376.9531 |         - |         - |  1159.91 KB |
 |    NpmOrg |   1.714 ms | 0.0132 ms | 0.0123 ms |   199.2188 |   54.6875 |         - |   739.91 KB |
 |  HugePage | 227.416 ms | 1.5071 ms | 1.4098 ms | 22262.5000 | 3195.8333 | 1437.5000 | 97776.85 KB |

Benchmark numbers after this PR:

 |    Method |       Mean |     Error |    StdDev |      Gen 0 |     Gen 1 |     Gen 2 |   Allocated |
 |---------- |-----------:|----------:|----------:|-----------:|----------:|----------:|------------:|
 |       Lhc |   6.294 ms | 0.0625 ms | 0.0585 ms |  3398.9583 |  125.0000 |   54.6875 | 12106.07 KB |
 | NodeJsOrg |   1.256 ms | 0.0195 ms | 0.0182 ms |   376.9531 |         - |         - |  1159.91 KB |
 |    NpmOrg |   1.647 ms | 0.0225 ms | 0.0211 ms |   199.2188 |   54.6875 |         - |   739.91 KB |
 |  HugePage | 234.636 ms | 2.3660 ms | 2.2132 ms | 22262.5000 | 3204.1667 | 1458.3333 |  97776.6 KB |
