### PR TITLE
Reduce temp tokenizer buffer allocations

### DIFF
--- a/src/Tokenizer.cs
+++ b/src/Tokenizer.cs
@@ -215,7 +215,7 @@ namespace High5
         public bool AllowCData { get; set; }
         public string State { get; set; }
         string returnState;
-        List<int> tempBuff;
+        Array<int> tempBuff;
         int additionalAllowedCp;
         string lastStartTagName;
         int consumedAfterSnapshot;
@@ -277,7 +277,7 @@ namespace High5
             this.State = DATA_STATE;
             this.returnState = "";
 
-            this.tempBuff = new List<int>();
+            this.tempBuff = new Array<int>();
             this.additionalAllowedCp = 0; // void 0
             this.lastStartTagName = "";
 
@@ -450,10 +450,10 @@ namespace High5
 
         bool IsTempBufferEqualToScriptString()
         {
-            if (this.tempBuff.Count != CPS.SCRIPT_STRING.Length)
+            if (this.tempBuff.Length != CPS.SCRIPT_STRING.Length)
                 return false;
 
-            for (var i = 0; i < this.tempBuff.Count; i++)
+            for (var i = 0; i < this.tempBuff.Length; i++)
             {
                 if (this.tempBuff[i] != CPS.SCRIPT_STRING[i])
                     return false;
@@ -590,6 +590,12 @@ namespace High5
                 type = TokenType.NULL_CHARACTER_TOKEN;
 
             this.AppendCharToCurrentCharacterToken(type, ToChar(cp));
+        }
+
+        void EmitSeveralCodePoints(Array<int> codePoints)
+        {
+            foreach (var cp in codePoints)
+                this.EmitCodePoint(cp.Value);
         }
 
         void EmitSeveralCodePoints(IEnumerable<int> codePoints)
@@ -982,7 +988,7 @@ namespace High5
             {
                 if (cp == CP.SOLIDUS)
                 {
-                    @this.tempBuff = new List<int>();
+                    @this.tempBuff.Clear();
                     @this.State = RCDATA_END_TAG_OPEN_STATE;
                 }
 
@@ -1064,7 +1070,7 @@ namespace High5
             {
                 if (cp == CP.SOLIDUS)
                 {
-                    @this.tempBuff = new List<int>();
+                    @this.tempBuff.Clear();
                     @this.State = RAWTEXT_END_TAG_OPEN_STATE;
                 }
 
@@ -1146,7 +1152,7 @@ namespace High5
             {
                 if (cp == CP.SOLIDUS)
                 {
-                    @this.tempBuff = new List<int>();
+                    @this.tempBuff.Clear();
                     @this.State = SCRIPT_DATA_END_TAG_OPEN_STATE;
                 }
 
@@ -1347,13 +1353,13 @@ namespace High5
             {
                 if (cp == CP.SOLIDUS)
                 {
-                    @this.tempBuff = new List<int>();
+                    @this.tempBuff.Clear();
                     @this.State = SCRIPT_DATA_ESCAPED_END_TAG_OPEN_STATE;
                 }
 
                 else if (IsAsciiLetter(cp))
                 {
-                    @this.tempBuff = new List<int>();
+                    @this.tempBuff.Clear();
                     @this.EmitChar('<');
                     @this.ReconsumeInState(SCRIPT_DATA_DOUBLE_ESCAPE_START_STATE);
                 }
@@ -1555,7 +1561,7 @@ namespace High5
             {
                 if (cp == CP.SOLIDUS)
                 {
-                    @this.tempBuff = new List<int>();
+                    @this.tempBuff.Clear();
                     @this.State = SCRIPT_DATA_DOUBLE_ESCAPE_END_STATE;
                     @this.EmitChar('/');
                 }


### PR DESCRIPTION
This PR uses our `Array<>` instead of a `List<>` for the temp tokenizer buffer, and more importantly, reduces the number of allocations by clearing and reusing the same array instead of allocating a new one each time.

Follow-on benchmark numbers from PR #3:

```
BenchmarkDotNet=v0.10.9, OS=Mac OS X 10.12
Processor=Intel Core i7-3720QM CPU 2.60GHz (Ivy Bridge), ProcessorCount=8
.NET Core SDK=2.0.0
  [Host]     : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
```

 |    Method |       Mean |     Error |    StdDev |      Gen 0 |     Gen 1 |     Gen 2 |   Allocated |
 |---------- |-----------:|----------:|----------:|-----------:|----------:|----------:|------------:|
 |       Lhc |   5.998 ms | 0.0493 ms | 0.0437 ms |  3367.1875 |  125.0000 |   54.6875 |  12105.2 KB |
 | NodeJsOrg |   1.219 ms | 0.0135 ms | 0.0120 ms |   376.9531 |         - |         - |  1159.17 KB |
 |    NpmOrg |   1.553 ms | 0.0178 ms | 0.0167 ms |   197.2656 |   58.5938 |         - |   738.51 KB |
 |  HugePage | 221.576 ms | 1.6100 ms | 1.4272 ms | 22170.8333 | 3329.1667 | 1483.3333 | 97775.76 KB |
