### PR TITLE
Use StringBuilder to build character token data

### DIFF
--- a/src/Parser.cs
+++ b/src/Parser.cs
@@ -612,12 +612,12 @@ namespace High5
                 {
                     this.skipNextNewLine = false;
 
-                    if (token is CharacterToken ctoken && token.Type == WHITESPACE_CHARACTER_TOKEN && ctoken.Chars[0] == '\n')
+                    if (token is CharacterToken ctoken && token.Type == WHITESPACE_CHARACTER_TOKEN && ctoken[0] == '\n')
                     {
-                        if (ctoken.Chars.Length == 1)
+                        if (ctoken.Length == 1)
                             continue;
 
-                        ctoken.Chars = ctoken.Chars.Substring(1);
+                        ctoken.Remove(0, 1);
                     }
                 }
 
@@ -3336,7 +3336,7 @@ namespace High5
         //------------------------------------------------------------------
         static void NullCharacterInForeignContent(Parser<Node, DocumentFragment, Element, Attr, TemplateElement, Comment> p, CharacterToken token)
         {
-            token.Chars = Unicode.ReplacementCharacter.ToString();
+            token.Clear(); token.Append(Unicode.ReplacementCharacter);
             p.InsertCharacters(token);
         }
 

--- a/src/Token.cs
+++ b/src/Token.cs
@@ -27,6 +27,7 @@ namespace High5
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Text;
     using static TokenType;
 
     abstract class Token
@@ -125,7 +126,12 @@ namespace High5
 
     sealed class CharacterToken : Token
     {
-        public string Chars { get; set; }
+        readonly StringBuilder _chars;
+        string _cachedString;
+
+        public char this[int index] => _chars[index];
+        public int Length => _chars.Length;
+        public string Chars => _cachedString ?? (_cachedString = _chars.ToString());
 
         public CharacterToken(TokenType type, char ch) :
             base(type)
@@ -133,7 +139,44 @@ namespace High5
             Debug.Assert(type == CHARACTER_TOKEN
                       || type == WHITESPACE_CHARACTER_TOKEN
                       || type == NULL_CHARACTER_TOKEN);
-            this.Chars = ch.ToString();
+            _chars = new StringBuilder().Append(ch);
         }
+
+        void InvalidateCache()
+        {
+            if (_cachedString == null)
+                return;
+            _cachedString = null;
+        }
+
+        public void Append(string s)
+        {
+            InvalidateCache();
+            _chars.Append(s);
+        }
+
+        public void Append(char ch)
+        {
+            InvalidateCache();
+            _chars.Append(ch);
+        }
+
+        public void Remove(int index, int length)
+        {
+            if (length == 0)
+                return;
+            InvalidateCache();
+            _chars.Remove(index, length);
+        }
+
+        public void Clear()
+        {
+            if (_chars.Length == 0)
+                return;
+            InvalidateCache();
+            _chars.Length = 0;
+        }
+
+        public override string ToString() => Chars;
     }
 }

--- a/src/Tokenizer.cs
+++ b/src/Tokenizer.cs
@@ -573,7 +573,7 @@ namespace High5
                 this.EmitCurrentCharacterToken();
 
             if (this.currentCharacterToken != null)
-                this.currentCharacterToken.Chars += ch;
+                this.currentCharacterToken.Append(ch);
 
             else
                 this.CreateCharacterToken(type, ch);


### PR DESCRIPTION
This PR is designed to reduce allocations of strings per character by using a `StringBuilder` instead for the character token data.

Follow-on benchmark numbers from PR #4:

``` 
BenchmarkDotNet=v0.10.9, OS=Mac OS X 10.12
Processor=Intel Core i7-3720QM CPU 2.60GHz (Ivy Bridge), ProcessorCount=8
.NET Core SDK=2.0.0
  [Host]     : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
```

|    Method |       Mean |     Error |    StdDev |      Gen 0 |     Gen 1 |     Gen 2 |    Allocated |
|---------- |-----------:|----------:|----------:|-----------:|----------:|----------:|-------------:|
|       Lhc |   4.704 ms | 0.0645 ms | 0.0603 ms |   781.2500 |  218.7500 |   62.5000 |   3034.38 KB |
| NodeJsOrg |   1.151 ms | 0.0224 ms | 0.0209 ms |   361.3281 |         - |         - |   1116.12 KB |
|    NpmOrg |   1.508 ms | 0.0239 ms | 0.0224 ms |   177.7344 |   58.5938 |         - |    634.94 KB |
|  HugePage | 220.950 ms | 2.0310 ms | 1.5856 ms | 23395.8333 | 3370.8333 | 1491.6667 | 101893.85 KB |
