### PR TITLE
Optimize foreach for arrays where possible

### DIFF
--- a/src/Doctype.cs
+++ b/src/Doctype.cs
@@ -170,7 +170,7 @@ namespace High5
 
             return DOCUMENT_MODE.NO_QUIRKS;
 
-            bool HasPrefix(string str, IEnumerable<string> prefixes)
+            bool HasPrefix(string str, string[] prefixes)
             {
                 foreach (var prefix in prefixes)
                 {

--- a/src/Tokenizer.cs
+++ b/src/Tokenizer.cs
@@ -588,15 +588,9 @@ namespace High5
                 this.EmitCodePoint(cp.Value);
         }
 
-        void EmitSeveralCodePoints(IEnumerable<CodePoint> codePoints)
+        void EmitSeveralCodePoints(CodePoint[] codePoints)
         {
             foreach (var cp in codePoints)
-                this.EmitCodePoint(cp);
-        }
-
-        void EmitSeveralCodePoints(IEnumerable<int> codePoints)
-        {
-            foreach (CodePoint cp in codePoints)
                 this.EmitCodePoint(cp);
         }
 
@@ -1785,8 +1779,8 @@ namespace High5
                 {
                     if (referencedCodePoints != null)
                     {
-                        foreach (CodePoint rcp in referencedCodePoints)
-                            rcp.AppendTo(@this.currentAttrValue);
+                        for (var i = 0; i < referencedCodePoints.Length; i++)
+                            referencedCodePoints[i].AppendTo(@this.currentAttrValue);
                     }
                     else
                         @this.currentAttrValue.Append('&');


### PR DESCRIPTION
This PR loops over arrays instead of generalizations like `IEnumerable<>` to avoid allocating enumerators and taking advantage of the fact that `foreach` loops for arrays are encoded as standard `for` loops.

Follow-on benchmark numbers from PR #6:

``` 
BenchmarkDotNet=v0.10.9, OS=Mac OS X 10.12
Processor=Intel Core i7-3720QM CPU 2.60GHz (Ivy Bridge), ProcessorCount=8
.NET Core SDK=2.0.0
  [Host]     : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT
```

|    Method |       Mean |     Error |    StdDev |      Gen 0 |     Gen 1 |     Gen 2 |   Allocated |
|---------- |-----------:|----------:|----------:|-----------:|----------:|----------:|------------:|
|       Lhc |   4.232 ms | 0.0829 ms | 0.0775 ms |   530.7292 |  233.8542 |   23.4375 |   1829.5 KB |
| NodeJsOrg |   1.046 ms | 0.0078 ms | 0.0069 ms |   300.7813 |         - |         - |   928.89 KB |
|    NpmOrg |   1.387 ms | 0.0118 ms | 0.0110 ms |   113.2813 |   37.1094 |         - |   388.02 KB |
|  HugePage | 211.372 ms | 1.7841 ms | 1.6688 ms | 19120.8333 | 3004.1667 | 1412.5000 | 80756.94 KB |
